### PR TITLE
The pointer cursor is a UI hint that something can be clicked on the …

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -49,5 +49,6 @@ Contributors:
   Darryl Pogue <darryl@dpogue.ca> (github: dpogue)
   tobimensch
   Ramiro Araujo <rama.araujo@gmail.com> (github: ramiroaraujo)
+  Tyler Elliott (github: tylercal)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -672,7 +672,9 @@ LocalHints =
     # Check for attributes that make an element clickable regardless of its tagName.
     if (element.hasAttribute("onclick") or
         element.getAttribute("role")?.toLowerCase() in ["button", "link"] or
-        element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
+        element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"] or
+        (document.defaultView.getComputedStyle(element, null).cursor == "pointer" and
+          document.defaultView.getComputedStyle(element.parentElement, null).cursor != "pointer"))
       isClickable = true
 
     # Check for jsaction event listeners on the element.


### PR DESCRIPTION
…page. This is often the simplest way to detect if a non-input, non-anchor element should have a hint. The "My Calendars" and "Other calendars" sections of Google Calendar are one example.

This change uses `getComputedStyle` to determine the value of an element's cursor. We only want to know the first element that sets its cursor to pointer. All children of that first element will also inherit the style and because this method includes inherited styles we need a special check to make sure a given style is in fact the first pointer in the tree.